### PR TITLE
Edit workflow with IODC, update ecs.tf on Security group only allow i…

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: feature-app
 
+permissions:
+  id-token: write
+
 jobs:
   build-and-push-image-to-ecr:
     runs-on: ubuntu-latest
@@ -15,8 +18,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::255945442255:role/grp2-oidc
           aws-region: ap-southeast-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -45,8 +47,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::255945442255:role/grp2-oidc
           aws-region: ap-southeast-1
       - name: Create AWS ECS cluster, task definition and service using Terraform
         run: |

--- a/ecs/ecs.tf
+++ b/ecs/ecs.tf
@@ -17,15 +17,8 @@ resource "aws_security_group" "ecs-sg" {
   name = "group2-ecs-sg"
   
   ingress {
-    from_port = 0
-    to_port = 65535
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-  
-  ingress {
-    from_port = 80
-    to_port = 80
+    from_port = 3000
+    to_port = 3000
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
- updated workflows/ecr.yml by using OIDC instead of AWS_SECRET_KEY
- updated ecs/ecs.tf security group inbound to only allow tcp/3000 instead of allowing from port 0-65535